### PR TITLE
Fix license typos after recent changes to object

### DIFF
--- a/ghascompliance/checks.py
+++ b/ghascompliance/checks.py
@@ -273,7 +273,7 @@ class Checks:
         for warning in warnings:
             Octokit.warning(
                 "Dependency License Warning :: {} = {}".format(
-                    warning.fullname, warning.licence
+                    warning.fullname, warning.license
                 )
             )
 
@@ -300,14 +300,14 @@ class Checks:
         violations.extend(dependencies.findNames(violations_names))
 
         for violation in violations:
-            if violation.name in ignores_names or violation.licence in ignores_ids:
+            if violation.name in ignores_names or violation.license in ignores_ids:
                 Octokit.debug(f"Skipping {violation} because in ignore list...")
                 continue
 
             if self.display:
                 Octokit.error(
                     "Dependency Graph Alert :: {} = {}".format(
-                        violation, violation.licence
+                        violation, violation.license
                     )
                 )
 


### PR DESCRIPTION
Minor fix to a naming issue with Dependency Object Licence -> License

![image](https://github.com/advanced-security/policy-as-code/assets/47423802/db79089f-4fdb-471b-ae30-a4fdadcc61ce)
