### PR TITLE
Fix using 'is_github_app_token' for cloning repos

### DIFF
--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -87,6 +87,7 @@ if __name__ == "__main__":
         reference=arguments.github_ref,
         token=arguments.github_token,
     )
+    GitHub.github_app = arguments.is_github_app_token
 
     Octokit.info(
         f"GitHub Repository :: {GitHub.repository.owner}/{GitHub.repository.repo}"


### PR DESCRIPTION
This is a simple change to fix issue #30. I tested running this fix against the same repos and policy files used when discovering the issue, and it resolved the problem.