### PR TITLE
Set Octokit logging level

### DIFF
--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
         level=logging.DEBUG if arguments.debug else logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+    Octokit.setLevel(logging.DEBUG if arguments.debug else logging.INFO)
 
     if arguments.debug:
         Octokit.debug("Debugging enabled")

--- a/ghascompliance/octokit/octokit.py
+++ b/ghascompliance/octokit/octokit.py
@@ -18,7 +18,7 @@ class Octokit:
     logger = logging.getLogger(__name__)
 
     @staticmethod
-    def setLevel(level: int=logging.INFO):
+    def setLevel(level: int = logging.INFO):
         """Set the logging level"""
         Octokit.logger.setLevel(level)
 

--- a/ghascompliance/octokit/octokit.py
+++ b/ghascompliance/octokit/octokit.py
@@ -18,6 +18,11 @@ class Octokit:
     logger = logging.getLogger(__name__)
 
     @staticmethod
+    def setLevel(level: int=logging.INFO):
+        """Set the logging level"""
+        Octokit.logger.setLevel(level)
+
+    @staticmethod
     def info(msg):
         """Logging Info"""
         logging.info(msg)


### PR DESCRIPTION
Octokit's logging level is not set correctly when debugging is enabled through either the `--debug` argvs option or through an environment variable.

This is a small fix for issue #35.  
Explicitly setting Octokit's logging level fixes the issue. For this fix I added a static method to Octokit that allows the logging level to be adjusted to avoid calling the `Octokit.logger` object from outside the class.