### PR TITLE
Fix .txt imports from cloned repos

### DIFF
--- a/ghascompliance/policy.py
+++ b/ghascompliance/policy.py
@@ -64,6 +64,7 @@ class Policy:
 
         # setup
         self.repository.clone_path = os.path.join(tempfile.gettempdir(), "repo")
+        self.temp_repo = self.repository.clone_path
         Octokit.debug(f"Clone Policy URL :: {self.repository.clone_url}")
 
         if os.path.exists(self.repository.clone_path):
@@ -214,7 +215,8 @@ class Policy:
                             continue
                         results.append(line)
 
-                break
+                return results
+        Octokit.warning(f"Unable to import file :: {path}")
         return results
 
     def savePolicy(self, path: str):


### PR DESCRIPTION
Quick fix for #37.  
The wrong path being used for cloned repos when attempting to find a valid path for import .txt files. The `self.temp_repo` variable in the `Policy` class was being set to `None` and was never updated correctly to the cloned repo's path.

Added a line to the `loadFromRepo()` function to set `self.temp_repo` after `self.repository.clone_path` is set. Also added a warning log message at the end of the `loadPolicyImport()` function to alert users if the import file was not found, hopefully this will make it easier for users to diagnose problems if their import file path is set wrong.