### PR TITLE
Bump setup-python action to v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '${{ matrix.python-version }}'
 

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
   using: "composite"
   steps:
     # Make sure 3.10 is installed
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 


### PR DESCRIPTION
Bumping the setup-python action to v4 to fix the Node12 deprecation warning when using setup-python v2.  
This fixes #39.