### PR TITLE
Output summary even if unknown exception occurs

### DIFF
--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -199,15 +199,18 @@ if __name__ == "__main__":
     except Exception as err:
         Octokit.error("Unknown Exception was hit, please repo this to " + __url__)
         Octokit.error(str(err))
+        Summary.addHeader(f"{Summary.__ICONS__['cross']} :: Error Encountered")
+        Summary.addLine(f"An unexpected exception was encountered while performing policy checks. Please report this to {__url__}")
+        Summary.addLine(Summary.formatItalics(str(err)))
 
         if arguments.debug:
             raise err
+    finally:
+        # Summary and PR comment
+        Summary.outputJobSummary()
+        PullRequest.addPrComment(policy.name)
 
     Octokit.info("Total unacceptable alerts :: " + str(errors))
-
-    # Summary and PR comment
-    Summary.outputJobSummary()
-    PullRequest.addPrComment(policy.name)
 
     if arguments.action == "break" and errors > 0:
         Octokit.error("Unacceptable Threshold of Risk has been hit!")

--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
     except Exception as err:
         Octokit.error("Unknown Exception was hit, please repo this to " + __url__)
         Octokit.error(str(err))
-        Summary.addHeader(f"{Summary.__ICONS__['cross']} :: Error Encountered")
+        Summary.addHeader(f"{Summary.__ICONS__['cross']} :: Error Encountered", 2)
         Summary.addLine(
             f"An unexpected exception was encountered while performing policy checks. Please report this to {__url__}"
         )

--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -200,7 +200,9 @@ if __name__ == "__main__":
         Octokit.error("Unknown Exception was hit, please repo this to " + __url__)
         Octokit.error(str(err))
         Summary.addHeader(f"{Summary.__ICONS__['cross']} :: Error Encountered")
-        Summary.addLine(f"An unexpected exception was encountered while performing policy checks. Please report this to {__url__}")
+        Summary.addLine(
+            f"An unexpected exception was encountered while performing policy checks. Please report this to {__url__}"
+        )
         Summary.addLine(Summary.formatItalics(str(err)))
 
         if arguments.debug:


### PR DESCRIPTION
This is a quick PR as a follow-up to the conversation in #44.  
Moved the lines for outputting the summary to a `finally` block for the `try/except` block for the checks. And added a few lines to the `except` block to add info about the error to the summary.