### PR TITLE
Use ignores in license warnings

### DIFF
--- a/ghascompliance/checks.py
+++ b/ghascompliance/checks.py
@@ -319,7 +319,7 @@ class Checks:
         if not self.policy.policy and not self.policy.policy.get("licensing"):
             Octokit.debug("Skipping as licensing policy not set")
             return len(licensing_violations)
-        
+
         ignores_ids = (
             self.policy.policy.get("licensing", {}).get("ignores", {}).get("ids", [])
         )

--- a/ghascompliance/checks.py
+++ b/ghascompliance/checks.py
@@ -319,6 +319,13 @@ class Checks:
         if not self.policy.policy and not self.policy.policy.get("licensing"):
             Octokit.debug("Skipping as licensing policy not set")
             return len(licensing_violations)
+        
+        ignores_ids = (
+            self.policy.policy.get("licensing", {}).get("ignores", {}).get("ids", [])
+        )
+        ignores_names = (
+            self.policy.policy.get("licensing", {}).get("ignores", {}).get("names", [])
+        )
 
         # Warnings (NA, etc)
         warnings = Dependencies()
@@ -334,6 +341,10 @@ class Checks:
         warnings.extend(dependencies.findNames(warnings_names))
 
         for warning in warnings:
+            if warning.name in ignores_names or warning.license in ignores_ids:
+                Octokit.debug(f"Skipping {warning} because in ignore list...")
+                continue
+
             licensing_warnings.append(
                 [warning.fullname, warning.license if warning.license else "None"]
             )
@@ -342,13 +353,6 @@ class Checks:
                     warning.fullname, warning.license
                 )
             )
-
-        ignores_ids = (
-            self.policy.policy.get("licensing", {}).get("ignores", {}).get("ids", [])
-        )
-        ignores_names = (
-            self.policy.policy.get("licensing", {}).get("ignores", {}).get("names", [])
-        )
 
         # License Checks (GPL, etc)
         violations = Dependencies()


### PR DESCRIPTION
This is a small change to use the license ignore list when determining the license warnings. This fixes the bug in #46 .

The `checkDependencyLicensing()` function was creating the ignore lists after finishing creating and outputting the warning lists. This PR moves the creation of the ignore lists earlier in the function and applies the same filtering logic for ignores to the warnings to match the logic used for the violations.