### PR TITLE
Add Base and Ref support to inputs

### DIFF
--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -43,6 +43,8 @@ github_arguments.add_argument("--github-instance", default=GITHUB_INSTANCE)
 github_arguments.add_argument("--github-repository", default=GITHUB_REPOSITORY)
 # github_arguments.add_argument("--github-event", default=GITHUB_EVENT_PATH)
 github_arguments.add_argument("--github-ref", default=GITHUB_REF)
+github_arguments.add_argument("--github-base-ref", default=None)
+github_arguments.add_argument("--github-head-ref", default=None)
 # github_arguments.add_argument("--workflow-event", default=GITHUB_EVENT_NAME)
 github_arguments.add_argument("--github-policy")
 github_arguments.add_argument("--github-policy-branch", default="main")
@@ -186,6 +188,8 @@ if __name__ == "__main__":
         display=arguments.display,
         results_path=results,
         caching=arguments.disable_caching,
+        base_ref=arguments.github_base_ref,
+        head_ref=arguments.github_head_ref,
     )
 
     errors = 0

--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -103,6 +103,10 @@ if __name__ == "__main__":
     )
     Octokit.info(f"GitHub Instance :: {GitHub.instance}")
     Octokit.info(f"GitHub Reference (branch/pr) :: {GitHub.repository.reference}")
+    if arguments.github_base_ref:
+        Octokit.info(f"GitHub Base Reference :: {arguments.github_base_ref}")
+    if arguments.github_head_ref:
+        Octokit.info(f"GitHub Head Reference :: {arguments.github_head_ref}")
 
     if arguments.list_severities:
         for severity in SEVERITIES:


### PR DESCRIPTION
This adds a rough input option for providing a base and a head entry to the checks.

I have not been able to properly validate this while issue #120 is pending, but the goal here is to be able to provide refs to do comparisons at any location.

Specifically I'm looking to use this with the global git SHA of 4b825dc642cb6eb9a060e54bf8d69288fbee4904 for an empty ref, if using the dependency review action (as we use the API calls on the back end as the same here for the submission API) we can compare against an empty commit to get every response automatically back as a failing result.

That functionality using that SHA with that action works so there is no reason it shouldn't work here. (or other branches)

I was a bit mixed about updating the existing GITHUB_REF value to be one of these so as this is directly associated to the checks themselves I decided to keep it in the format as defined in this PR.

Feel free to make changes, this was a real rough breakdown and while I'm still having active issues with #120 theoretically that shouldn't stop this.