### PR TITLE
Fix/code scanning workflow dispatch

### DIFF
--- a/ghascompliance/checks.py
+++ b/ghascompliance/checks.py
@@ -159,10 +159,10 @@ class Checks:
             ids = []
             # Rule ID
             ids.append(alert.rule_id)
-            # TODO: CWE?
+            # TODO: CWE?
 
             names = []
-            #  Rule Name
+            # Rule Name
             names.append(rule_name)
 
             alert_creation_time = datetime.strptime(
@@ -293,15 +293,15 @@ class Checks:
                 alert_creation_time = datetime.now()
 
             ids = []
-            #  GitHub Advisory
+            # GitHub Advisory
             ids.append(alert.advisory.ghsa_id.lower())
-            #  CWE support
+            # CWE support
             ids.extend(alert.advisory.cwes)
 
             names = [
                 # org.apache.commons
                 dependency.fullname,
-                #  maven://org.apache.commons
+                # maven://org.apache.commons
                 dependency.getPurl(version=False),
             ]
 
@@ -532,7 +532,7 @@ class Checks:
             # manager + name + version
             names.append(dependency.getPurl())
 
-            #  none is set to just check if the name or pattern is discovered
+            # none is set to just check if the name or pattern is discovered
             if self.policy.checkViolation("none", "dependencies", names=names, ids=ids):
                 dependency_violations.append([dependency.fullname])
                 if self.display:

--- a/ghascompliance/checks.py
+++ b/ghascompliance/checks.py
@@ -96,16 +96,58 @@ class Checks:
             Octokit.info(
                 f"Code Scanning retries enabled :: x{self.retry_count}/{self.retry_sleep}s"
             )
-            pr_base = (
-                GitHub.repository.getPullRequestInfo().get("base", {}).get("ref", "")
-            )
-            alerts = codescanning.getAlertsInPR(pr_base)
+            try:
+                pr_info = GitHub.repository.getPullRequestInfo()
+                pr_base = pr_info.get("base", {}).get("ref", "")
+                
+                # Try different refs in order of preference
+                refs_to_try = [
+                    f"refs/pull/{GitHub.repository.getPullRequestNumber()}/merge",
+                    f"refs/pull/{GitHub.repository.getPullRequestNumber()}/head",
+                    pr_base,
+                    None
+                ]
+                
+                alerts = None
+                for ref in refs_to_try:
+                    try:
+                        if ref:
+                            Octokit.info(f"Attempting to get alerts with ref: {ref}")
+                            alerts = codescanning.getAlerts("open", ref=ref)
+                        else:
+                            Octokit.info("Attempting to get alerts without ref")
+                            alerts = codescanning.getAlertsInPR(pr_base)
+                            
+                        if alerts:
+                            Octokit.info(f"Successfully found {len(alerts)} alerts")
+                            break
+                    except Exception as e:
+                        if "Code scanning alerts" in str(e) and "repository permissions" in str(e):
+                            Octokit.error("Permission error: Ensure token has 'security_events: read' permission")
+                            raise e
+                        Octokit.warning(f"Failed to get alerts with ref {ref}: {str(e)}")
+                        continue
+                
+                if not alerts:
+                    alerts = []
+                    Octokit.warning("No alerts found with any reference method")
+
+            except Exception as e:
+                Octokit.error(f"Failed to check code scanning: {str(e)}")
+                return 1
 
         else:
-            Octokit.debug(
-                f"Code Scanning Alerts from reference :: {GitHub.repository.reference}"
-            )
-            alerts = codescanning.getAlerts("open", ref=GitHub.repository.reference)
+            try:
+                Octokit.debug(
+                    f"Code Scanning Alerts from reference :: {GitHub.repository.reference}"
+                )
+                alerts = codescanning.getAlerts("open", ref=GitHub.repository.reference)
+            except Exception as e:
+                if "Code scanning alerts" in str(e) and "repository permissions" in str(e):
+                    Octokit.error("Permission error: Ensure token has 'security_events: read' permission")
+                    raise e
+                Octokit.error(f"Failed to get alerts: {str(e)}")
+                return 1
 
         Octokit.info("Total Code Scanning Alerts :: " + str(len(alerts)))
 

--- a/vendor/ghastoolkit/octokit/codescanning.py
+++ b/vendor/ghastoolkit/octokit/codescanning.py
@@ -371,20 +371,34 @@ class CodeScanning:
         if not self.repository.reference or not self.repository.isInPullRequest():
             raise GHASToolkitError("Repository is not in a Pull Request")
 
-        # Try merge and then head
-        analysis = self.getAnalyses(reference=self.repository.reference)
+        # Get PR info to determine the correct reference
+        pr_info = self.repository.getPullRequestInfo()
+        if not pr_info:
+            raise GHASToolkitError("Could not get PR information")
+            
+        # Try head ref first, then merge ref
+        head_ref = f"refs/pull/{self.repository.getPullRequestNumber()}/head"
+        merge_ref = f"refs/pull/{self.repository.getPullRequestNumber()}/merge"
+        
+        logger.debug(f"Trying head ref first: {head_ref}")
+        analysis = self.getAnalyses(reference=head_ref)
+        
+        if len(analysis) == 0:
+            logger.debug(f"No analyses found for head ref, trying merge ref: {merge_ref}")
+            analysis = self.getAnalyses(reference=merge_ref)
+
         if len(analysis) == 0:
             raise GHASToolkitError("No analyses found for the PR")
 
         # For CodeQL results using Default Setup
-        reference = analysis[0].get("ref")
+        reference = analysis[0].ref
         if not reference:
             raise GHASToolkitError("No ref found in the analysis")
 
         alerts = self.getAlerts("open", ref=reference)
 
         for alert in alerts:
-            number = alert.get("number")
+            number = alert.number
             alert_info = self.getAlertInstances(number, ref=base)
             if len(alert_info) == 0:
                 results.append(alert)
@@ -447,7 +461,11 @@ class CodeScanning:
         https://docs.github.com/en/enterprise-cloud@latest/rest/code-scanning#list-code-scanning-analyses-for-a-repository
         """
         ref = reference or self.repository.reference
-        logger.debug(f"Getting Analyses for {ref}")
+        logger.debug(f"Getting Analyses for ref: {ref}")
+        logger.debug(f"Repository reference: {self.repository.reference}")
+        logger.debug(f"Repository branch: {self.repository.branch}")
+        logger.debug(f"Is in PR: {self.repository.isInPullRequest()}")
+        
         if ref is None:
             raise GHASToolkitError("Reference is required for getting analyses")
 
@@ -464,6 +482,8 @@ class CodeScanning:
                 "/repos/{org}/{repo}/code-scanning/analyses",
                 {"tool_name": tool, "ref": ref},
             )
+            logger.debug(f"Initial API response for ref {ref}: {len(results) if isinstance(results, list) else 'error'} results")
+            
             if not isinstance(results, list):
                 raise GHASToolkitTypeError(
                     "Error getting analyses from Repository",
@@ -480,10 +500,14 @@ class CodeScanning:
                 and (ref.endswith("/merge") or ref.endswith("/head"))
             ):
                 logger.debug("No analyses found for `merge`, trying `head`")
+                head_ref = ref.replace("/merge", "/head")
+                logger.debug(f"Trying head ref: {head_ref}")
                 results = self.rest.get(
                     "/repos/{org}/{repo}/code-scanning/analyses",
-                    {"tool_name": tool, "ref": ref.replace("/merge", "/head")},
+                    {"tool_name": tool, "ref": head_ref},
                 )
+                logger.debug(f"Head ref API response: {len(results) if isinstance(results, list) else 'error'} results")
+                
                 if not isinstance(results, list):
                     raise GHASToolkitTypeError(
                         "Error getting analyses from Repository",

--- a/vendor/ghastoolkit/octokit/repository.py
+++ b/vendor/ghastoolkit/octokit/repository.py
@@ -53,6 +53,12 @@ class Repository:
             if not self.isInPullRequest():
                 _, _, branch = self.reference.split("/", 2)
                 self.branch = branch
+            else:
+                # For PRs, try to get the head branch
+                pr_info = self.getPullRequestInfo()
+                if pr_info and "head" in pr_info:
+                    self.branch = pr_info["head"].get("ref")
+                    
         if self.branch and not self.reference:
             self.reference = f"refs/heads/{self.branch}"
 


### PR DESCRIPTION
This PR improves how code scanning analyses are retrieved when triggered by `workflow_dispatch` events, particularly in the context of `pull requests`. 

Changes include enhanced PR reference handling, better debug logging, and improved property access on CodeAlert objects. The changes ensure that both head and merge refs are tried in the correct order, providing better support for `workflow_dispatch` events in pull request contexts.


This occurs because during workflow_dispatch events, the reference handling wasn't properly considering the PR context, leading to failed analysis retrieval.

1. Enhanced PR reference handling to properly try both head and merge refs:
```python
# Before: Only tried repository reference
analysis = self.getAnalyses(reference=self.repository.reference)

# After: Explicitly try PR-specific references
merge_ref = f'refs/pull/{self.repository.getPullRequestNumber()}/merge'
head_ref = f'refs/pull/{self.repository.getPullRequestNumber()}/head'


# Try head ref first (more accurate for workflow_dispatch)
analysis = self.getAnalyses(reference=head_ref)
if len(analysis) == 0:
    analysis = self.getAnalyses(reference=merge_ref)
```

2. Added proper PR head branch detection from PR info:
```python
# Added PR head branch detection
pr_info = self.repository.getPullRequestInfo()
if pr_info and "head" in pr_info:
    self.branch = pr_info["head"].get("ref")
```

3. Added better debug logging:
```python
logger.debug(f'Getting Analyses for ref: {ref}')
logger.debug(f'Repository reference: {self.repository.reference}')
logger.debug(f'Repository branch: {self.repository.branch}')
logger.debug(f'Is in PR: {self.repository.isInPullRequest()}')
```

4. Fixed property access on CodeAlert objects:
   - Standardized property access patterns
   - Fixed inconsistencies between dict-style and property access
   - Added proper type handling for CodeAlert properties

### overview
This fix ensures that code scanning analyses are properly retrieved during workflow_dispatch events in pull requests, which is particularly important for:
- Manual re-runs of code scanning checks
- Custom workflow triggers
- Integration with other CI/CD processes

The changes maintain backward compatibility while improving the robustness of the code scanning analysis retrieval process.

### Testing
The changes have been tested with:
- Regular pull request checks
- workflow_dispatch events in pull requests
- Different reference formats (head and merge)
- Various PR states and configurations

### Documentation
For more information about the code scanning API endpoints being used, see:
https://docs.github.com/en/enterprise-cloud@latest/rest/code-scanning#list-code-scanning-analyses-for-a-repository


Reopening here as well since there are some other changes - After playing around with a few different setups.