### PR TITLE
feat(ci): add Release workflow to automate release mechanics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+# Handles all release mechanics via advanced-security/reusable-workflows,
+# replacing the previous fully-manual process (hand-bump .release.yml +
+# ghascompliance/__version__.py, then hand-run `gh release create`).
+#
+# Two paths, both calling into the same reusable release tooling:
+#   - auto-release: fires when .release.yml's version changes on main (the
+#     normal release flow) - reuses python-release.yml's existing
+#     cooldown-aware version-vs-latest-release check, so it's a no-op if
+#     .release.yml changed without an actual version bump. Always a full
+#     release (never a pre-release), since a committed .release.yml bump
+#     represents a finalized version.
+#   - manual-release: workflow_dispatch for on-demand releases, including
+#     pre-releases (e.g. a beta cut ahead of finalizing .release.yml).
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '.release.yml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Explicit version to release (e.g. 2.12.0 or 2.12.0-beta.1). Leave blank to auto-bump from the latest release.'
+        required: false
+        type: string
+      bump:
+        description: 'Auto-bump type, used only when "version" above is left blank.'
+        required: false
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+      prerelease:
+        description: 'Publish as a pre-release (tags vX.Y.Z only; skips moving the floating vX/vX.Y tags and skips --latest).'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-release:
+    if: ${{ github.event_name == 'push' && github.repository == 'advanced-security/policy-as-code' }}
+    uses: advanced-security/reusable-workflows/.github/workflows/python-release.yml@v0.3.5
+    secrets: inherit
+
+  manual-release:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'advanced-security/policy-as-code' }}
+    uses: advanced-security/reusable-workflows/.github/workflows/release.yml@v0.3.5
+    with:
+      version: ${{ inputs.version }}
+      bump: ${{ inputs.bump }}
+      prerelease: ${{ inputs.prerelease }}
+    secrets: inherit


### PR DESCRIPTION
## Why

Today, releasing `policy-as-code` is entirely manual: a maintainer hand-bumps `.release.yml`'s `version` and `ghascompliance/__version__.py` in the same commit, then hand-runs `gh release create`. Nothing in this repo's own CI wires up the release automation that `advanced-security/reusable-workflows` already provides — I verified none of the existing 8 workflows reference `python-release.yml` or `release.yml`. There's also no way to publish a pre-release without doing it by hand.

## What this adds

`.github/workflows/release.yml` with two paths, both calling into `advanced-security/reusable-workflows` (pinned `@v0.3.5`, matching the pin already used internally by `python-release.yml`; verified both files exist at that tag and match `@main`'s current content):

- **`auto-release`** — fires on push to `main` when `.release.yml` changes. Calls `python-release.yml@v0.3.5`, reusing its existing cooldown-aware check that compares `.release.yml`'s version against the latest GitHub release and only releases when it actually changed (so it's a safe no-op if `.release.yml` changes without a version bump). Always a full release, never a pre-release — a committed `.release.yml` bump represents a finalized version.

- **`manual-release`** — `workflow_dispatch` with `version` (explicit override), `bump` (patch/minor/major, used when `version` is blank), and `prerelease` (boolean) inputs. Calls `release.yml@v0.3.5` directly, for on-demand releases including pre-releases (e.g. a beta cut ahead of finalizing `.release.yml`). `prerelease: true` tags only the full `vX.Y.Z` (skips moving the floating `vX`/`vX.Y` tags that Action consumers typically pin to) and skips marking the release `--latest`.

## Notes / out of scope

- `pull-requests: write` is granted (in addition to `contents: write`) because `python-release.yml` declares wanting it, even though the specific path we exercise (`update-readme-sha` left at its default `false`) doesn't actually need it — avoids a permission-scoping surprise.
- Two related gaps found while investigating, intentionally left out of this PR since they're separate concerns: (1) `ghascompliance/__version__.py` is still hand-kept in sync with `.release.yml`'s version rather than derived; (2) `.release.yml`'s own `locations.paths: ["*.md", "docs/*.md"]` doesn't match nested docs, so e.g. `docs/introduction/actions.md` has been stuck referencing `@v2.7.0` since early 2024 even though README.md is correctly updated to `@v2.11.1`.